### PR TITLE
Feature: reading user's tool config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = { version = "1.0.198", features = ["derive"] }
+toml = "0.8.12"

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,0 +1,5 @@
+title = "mk8_integrity config"
+
+[config]
+game_path = "~/Documents/Dumpling/Updates/mk8/"
+cemu_path = "~/Documents/CEMU/"

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,5 +1,3 @@
-title = "mk8_integrity config"
-
-[config]
-game_path = "~/Documents/Dumpling/Updates/mk8/"
-cemu_path = "~/Documents/CEMU/"
+[paths]
+mk8_folder = "~/Documents/Dumpling/Updates/mk8/"
+cemu_folder = "~/Documents/CEMU/"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,9 @@
 use serde::Deserialize;
 use std::fs;
 
+/// ## Paths
+///
+/// The path to the folder where `MK8` and `CEMU` are installed
 #[derive(Deserialize, Debug)]
 pub struct Paths {
     mk8_folder: String,
@@ -8,6 +11,9 @@ pub struct Paths {
     // add other paths
 }
 
+/// ## Config
+///
+/// The configuration of the program
 #[derive(Deserialize, Debug)]
 pub struct Config {
     paths: Paths,
@@ -15,6 +21,7 @@ pub struct Config {
 }
 
 impl Config {
+    /// Prints the config of the program as a debug message
     pub fn print_config(&self) {
         dbg!(&self);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,14 +26,21 @@ impl Config {
         dbg!(&self);
     }
 
-    pub fn new() -> Config {
+    pub fn new() -> Option<Config> {
         let file_path = "config/config.toml";
-        let contents =
-            fs::read_to_string(file_path).expect("Should have been able to read the file");
+        let contents = fs::read_to_string(file_path);
 
-        let config: Config =
-            toml::from_str(&contents).expect("The TOML should be properly formatted");
-
-        config
+        if let Ok(str_contents) = contents {
+            let config: Result<Config, toml::de::Error> = toml::from_str(&str_contents);
+            if let Ok(parsed_config) = config {
+                Some(parsed_config)
+            } else {
+                eprintln!("Error paersing TOML: {:?}", config.unwrap_err());
+                None
+            }
+        } else {
+            eprintln!("Error reading file: {:?}", contents.unwrap_err());
+            None
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,20 +1,25 @@
 use serde::Deserialize;
 use std::fs;
 
-#[derive(Deserialize)]
-pub struct Config {
-    config: ToolsSettings,
+#[derive(Deserialize, Debug)]
+pub struct Paths {
+    mk8_folder: String,
+    cemu_folder: String,
+    // add other paths
 }
 
 #[derive(Deserialize, Debug)]
-pub struct ToolsSettings {
-    game_path: String,
-    cemu_path: String,
-    // add other settings
+pub struct Config {
+    paths: Paths,
+    // add other config options (moss, ...)
 }
 
-impl ToolsSettings {
-    pub fn new() -> Self {
+impl Config {
+    pub fn print_config(&self) {
+        dbg!(&self);
+    }
+
+    pub fn new() -> Config {
         let file_path = "config/config.toml";
         let contents =
             fs::read_to_string(file_path).expect("Should have been able to read the file");
@@ -22,9 +27,6 @@ impl ToolsSettings {
         let config: Config =
             toml::from_str(&contents).expect("The TOML should be properly formatted");
 
-        // Debug print
-        println!("{:?}", config.config);
-
-        config.config
+        config
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+// mod file_integrity;
+mod tool_settings;
+
 fn main() {
     println!("Hello, world!");
+    tool_settings::ToolsSettings::new();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
-// mod file_integrity;
-mod tool_settings;
+use config::Config;
+
+mod config;
 
 fn main() {
-    println!("Hello, world!");
-    tool_settings::ToolsSettings::new();
+    let cfg = Config::new();
+    Config::print_config(&cfg)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,14 @@ use config::Config;
 mod config;
 
 fn main() {
-    let cfg = Config::new();
-    Config::print_config(&cfg)
+    match Config::new() {
+        Some(cfg) => {
+            Config::print_config(&cfg);
+        }
+        None => {
+            eprintln!("Failed to load configuration.");
+            std::process::exit(-84); // Can we also define `const` like c/c++ (const ERROR_STATUS =
+                                     // -84)
+        }
+    }
 }

--- a/src/tool_settings.rs
+++ b/src/tool_settings.rs
@@ -1,0 +1,30 @@
+use serde::Deserialize;
+use std::fs;
+
+#[derive(Deserialize)]
+pub struct Config {
+    config: ToolsSettings,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ToolsSettings {
+    game_path: String,
+    cemu_path: String,
+    // add other settings
+}
+
+impl ToolsSettings {
+    pub fn new() -> Self {
+        let file_path = "config/config.toml";
+        let contents =
+            fs::read_to_string(file_path).expect("Should have been able to read the file");
+
+        let config: Config =
+            toml::from_str(&contents).expect("The TOML should be properly formatted");
+
+        // Debug print
+        println!("{:?}", config.config);
+
+        config.config
+    }
+}


### PR DESCRIPTION
## Description

Accessing a `config.toml` file in `/config/` directory to fill the `Settings` struct.

### Base config

- Path to game files
- Path to CEMU files
